### PR TITLE
Ensure save_pcap creates directory

### DIFF
--- a/netwatchdog/storage.py
+++ b/netwatchdog/storage.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 def save_pcap(packets: Iterable[ParsedPacket], filename: str) -> Path:
     path = config.PCAP_DIR / filename
     raw_packets = [pkt.raw for pkt in packets if pkt.raw]
+    path.parent.mkdir(parents=True, exist_ok=True)
     wrpcap(str(path), raw_packets)
     logger.info("Saved PCAP to %s", path)
     return path

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from netwatchdog import storage, config
+
+class DummyPacket:
+    def __init__(self, raw):
+        self.raw = raw
+
+
+def test_save_pcap_creates_directory(tmp_path, monkeypatch):
+    pcap_dir = tmp_path / "pcap"
+    monkeypatch.setattr(config, "PCAP_DIR", pcap_dir)
+    assert not pcap_dir.exists()
+
+    packets = [DummyPacket(b"foo"), DummyPacket(b"bar")]
+    filename = "test.pcap"
+    path = storage.save_pcap(packets, filename)
+
+    assert path == pcap_dir / filename
+    assert path.exists()


### PR DESCRIPTION
## Summary
- create parent directory before saving pcap
- test save_pcap creates config.PCAP_DIR when missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619d248eac83339ef3d4a20001c1f0