### PR TITLE
Ensure exporter mkdirs

### DIFF
--- a/netwatchdog/exporter.py
+++ b/netwatchdog/exporter.py
@@ -11,6 +11,7 @@ from .packet_parser import ParsedPacket
 
 
 def export_csv(packets: Iterable[ParsedPacket], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["timestamp", "protocol", "src", "dst", "sport", "dport"])
@@ -37,4 +38,5 @@ def export_json(packets: Sequence[ParsedPacket], path: Path) -> None:
         }
         for pkt in packets
     ]
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2))

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from netwatchdog import exporter
+from netwatchdog.packet_parser import ParsedPacket
+
+
+def test_export_csv_creates_directory(tmp_path):
+    path = tmp_path / "exports" / "data.csv"
+    packets = [ParsedPacket(protocol="TCP", src="1.1.1.1", dst="2.2.2.2", sport=1234, dport=80)]
+    exporter.export_csv(packets, path)
+    assert path.exists()
+
+
+def test_export_json_creates_directory(tmp_path):
+    path = tmp_path / "exports" / "data.json"
+    packets = [ParsedPacket(protocol="UDP", src="1.1.1.1", dst="2.2.2.2", sport=53, dport=53)]
+    exporter.export_json(packets, path)
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data[0]["protocol"] == "UDP"


### PR DESCRIPTION
## Summary
- create parent directories before exporting csv/json files
- add exporter tests for missing directory handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619de2bba4833390abd211c6b1075d