### PR TITLE
Skip saving empty PCAPs

### DIFF
--- a/netwatchdog/storage.py
+++ b/netwatchdog/storage.py
@@ -19,6 +19,9 @@ def save_pcap(packets: Iterable[ParsedPacket], filename: str) -> Path:
     path = config.PCAP_DIR / filename
     raw_packets = [pkt.raw for pkt in packets if pkt.raw]
     path.parent.mkdir(parents=True, exist_ok=True)
+    if not raw_packets:
+        logger.warning("No packets to save for %s", path)
+        return path
     wrpcap(str(path), raw_packets)
     logger.info("Saved PCAP to %s", path)
     return path

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -24,3 +24,15 @@ def test_save_pcap_creates_directory(tmp_path, monkeypatch):
 
     assert path == pcap_dir / filename
     assert path.exists()
+
+
+def test_save_pcap_no_packets(tmp_path, monkeypatch):
+    pcap_dir = tmp_path / "pcap"
+    monkeypatch.setattr(config, "PCAP_DIR", pcap_dir)
+
+    packets: list[DummyPacket] = []
+    filename = "empty.pcap"
+    path = storage.save_pcap(packets, filename)
+
+    assert path == pcap_dir / filename
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- guard against writing empty packet captures
- add regression test for empty PCAP save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a38047208333acff9fec63928dba