### PR TITLE
Add capture summary feature

### DIFF
--- a/netwatchdog/README.md
+++ b/netwatchdog/README.md
@@ -13,11 +13,12 @@ terminal.
 - [scapy](https://scapy.net/) for packet capture
 - [rich](https://rich.readthedocs.io/) for the CLI dashboard
 - Optional: `geoip2` for GeoIP lookups
+- Optional: `openai` for AI-generated summaries
 
 Install dependencies using pip:
 
 ```bash
-pip install scapy rich geoip2
+pip install scapy rich geoip2 openai  # optional
 ```
 
 ## Usage
@@ -48,3 +49,11 @@ python -m netwatchdog.main
 # from any other directory
 PYTHONPATH=/path/to/netwatchdog python -m netwatchdog.main
 ```
+
+## Summaries
+
+After processing traffic or analyzing a PCAP, NetWatchdog prints a concise
+summary of observed protocols and active sessions. To generate an AI-powered
+summary instead, install the optional `openai` package and set the environment
+variable `NETWATCHDOG_USE_AI=1`. The OpenAI API key is read from
+`OPENAI_API_KEY`.

--- a/netwatchdog/main.py
+++ b/netwatchdog/main.py
@@ -15,6 +15,7 @@ from .packet_parser import parse_packet
 from .session_tracker import SessionTracker
 from .stats_engine import StatsEngine
 from .storage import save_pcap, load_pcap
+from .summarizer import summarize
 
 logging.basicConfig(
     level=logging.INFO,
@@ -47,6 +48,7 @@ def main() -> None:
             alerts.process(parsed)
         dashboard = CLIDashboard(stats)
         dashboard.render()
+        print(summarize(stats, sessions))
         return
 
     def handle_packet(packet: object) -> None:
@@ -68,6 +70,7 @@ def main() -> None:
         logger.info("Stopping NetWatchdog")
         capturer.stop()
         dashboard.stop()
+        print(summarize(stats, sessions))
         save_pcap(captured, "capture.pcap")
         exit(0)
 

--- a/netwatchdog/summarizer.py
+++ b/netwatchdog/summarizer.py
@@ -1,0 +1,57 @@
+"""Generate human readable summaries of capture statistics."""
+from __future__ import annotations
+
+import os
+import logging
+
+from .stats_engine import StatsEngine
+from .session_tracker import SessionTracker, Session
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional
+    openai = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def _build_text_summary(stats: StatsEngine, sessions: SessionTracker) -> str:
+    """Return a plain text summary of stats and sessions."""
+    lines: list[str] = []
+    lines.append("Protocol counts:")
+    for proto, count in stats.get_protocol_counts().items():
+        lines.append(f"  {proto}: {count}")
+    active = sessions.get_active_sessions()
+    if not active:
+        lines.append("No active sessions.")
+    else:
+        lines.append("Active sessions:")
+        for s in active.values():
+            lines.append(
+                f"  {s.src}:{s.sport} -> {s.dst}:{s.dport} "
+                f"packets={s.packet_count} bytes={s.bytes}"
+            )
+    return "\n".join(lines)
+
+
+def summarize(stats: StatsEngine, sessions: SessionTracker) -> str:
+    """Generate a summary of the capture.
+
+    If the ``NETWATCHDOG_USE_AI`` environment variable is set and the ``openai``
+    package is available, an AI-generated summary will be returned. The API key
+    is read from ``OPENAI_API_KEY``. Otherwise a simple text summary is used.
+    """
+
+    summary = _build_text_summary(stats, sessions)
+    if os.getenv("NETWATCHDOG_USE_AI") and openai is not None:
+        try:
+            openai.api_key = os.getenv("OPENAI_API_KEY")
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": f"Summarize:\n{summary}"}],
+                max_tokens=150,
+            )
+            return response.choices[0].message["content"].strip()
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error("AI summary failed: %s", exc)
+    return summary

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from netwatchdog.stats_engine import StatsEngine
+from netwatchdog.session_tracker import SessionTracker, Session
+from netwatchdog.summarizer import summarize
+
+
+def test_plain_summary(monkeypatch):
+    monkeypatch.delenv("NETWATCHDOG_USE_AI", raising=False)
+    stats = StatsEngine()
+    stats.protocol_counts["TCP"] = 2
+    sessions = SessionTracker()
+    sessions.sessions[("1.1.1.1", "2.2.2.2", 1234, 80)] = Session(
+        src="1.1.1.1",
+        dst="2.2.2.2",
+        sport=1234,
+        dport=80,
+        packet_count=1,
+        bytes=100,
+    )
+    summary = summarize(stats, sessions)
+    assert "TCP: 2" in summary
+    assert "1.1.1.1:1234 -> 2.2.2.2:80" in summary


### PR DESCRIPTION
## Summary
- summarize StatsEngine & SessionTracker
- optionally use OpenAI for AI summaries via env var
- print summaries after capture or analysis
- document optional AI summary
- test local summary path

## Testing
- `pip install scapy rich`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a43454bc8333a25bf7e79356b40a