### PR TITLE
Add GeoIP integration

### DIFF
--- a/netwatchdog/exporter.py
+++ b/netwatchdog/exporter.py
@@ -8,13 +8,23 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 from .packet_parser import ParsedPacket
+from .utils import geoip
 
 
 def export_csv(packets: Iterable[ParsedPacket], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["timestamp", "protocol", "src", "dst", "sport", "dport"])
+        writer.writerow([
+            "timestamp",
+            "protocol",
+            "src",
+            "dst",
+            "sport",
+            "dport",
+            "src_geo",
+            "dst_geo",
+        ])
         for pkt in packets:
             writer.writerow([
                 int(pkt.raw.time) if pkt.raw else 0,
@@ -23,6 +33,8 @@ def export_csv(packets: Iterable[ParsedPacket], path: Path) -> None:
                 pkt.dst,
                 pkt.sport or "",
                 pkt.dport or "",
+                geoip.lookup(pkt.src) or "",
+                geoip.lookup(pkt.dst) or "",
             ])
 
 
@@ -35,6 +47,8 @@ def export_json(packets: Sequence[ParsedPacket], path: Path) -> None:
             "dst": pkt.dst,
             "sport": pkt.sport,
             "dport": pkt.dport,
+            "src_geo": geoip.lookup(pkt.src),
+            "dst_geo": geoip.lookup(pkt.dst),
         }
         for pkt in packets
     ]

--- a/netwatchdog/summarizer.py
+++ b/netwatchdog/summarizer.py
@@ -6,6 +6,7 @@ import logging
 
 from .stats_engine import StatsEngine
 from .session_tracker import SessionTracker, Session
+from .utils import geoip
 
 try:
     import openai  # type: ignore
@@ -27,8 +28,13 @@ def _build_text_summary(stats: StatsEngine, sessions: SessionTracker) -> str:
     else:
         lines.append("Active sessions:")
         for s in active.values():
+            src_geo = geoip.lookup(s.src)
+            dst_geo = geoip.lookup(s.dst)
+            geo_part = ""
+            if src_geo or dst_geo:
+                geo_part = f" ({src_geo or '?'} -> {dst_geo or '?'})"
             lines.append(
-                f"  {s.src}:{s.sport} -> {s.dst}:{s.dport} "
+                f"  {s.src}:{s.sport} -> {s.dst}:{s.dport}{geo_part} "
                 f"packets={s.packet_count} bytes={s.bytes}"
             )
     return "\n".join(lines)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -8,17 +8,39 @@ from netwatchdog import exporter
 from netwatchdog.packet_parser import ParsedPacket
 
 
-def test_export_csv_creates_directory(tmp_path):
+def test_export_csv_creates_directory(tmp_path, monkeypatch):
     path = tmp_path / "exports" / "data.csv"
     packets = [ParsedPacket(protocol="TCP", src="1.1.1.1", dst="2.2.2.2", sport=1234, dport=80)]
+
+    monkeypatch.setattr(
+        "netwatchdog.utils.geoip.lookup",
+        lambda ip: {"1.1.1.1": "A", "2.2.2.2": "B"}.get(ip),
+    )
+
     exporter.export_csv(packets, path)
     assert path.exists()
+    rows = path.read_text().splitlines()
+    header = rows[0].split(",")
+    assert "src_geo" in header and "dst_geo" in header
+    data = rows[1].split(",")
+    idx_src = header.index("src_geo")
+    idx_dst = header.index("dst_geo")
+    assert data[idx_src] == "A"
+    assert data[idx_dst] == "B"
 
 
-def test_export_json_creates_directory(tmp_path):
+def test_export_json_creates_directory(tmp_path, monkeypatch):
     path = tmp_path / "exports" / "data.json"
     packets = [ParsedPacket(protocol="UDP", src="1.1.1.1", dst="2.2.2.2", sport=53, dport=53)]
+
+    monkeypatch.setattr(
+        "netwatchdog.utils.geoip.lookup",
+        lambda ip: {"1.1.1.1": "A", "2.2.2.2": "B"}.get(ip),
+    )
+
     exporter.export_json(packets, path)
     assert path.exists()
     data = json.loads(path.read_text())
     assert data[0]["protocol"] == "UDP"
+    assert data[0]["src_geo"] == "A"
+    assert data[0]["dst_geo"] == "B"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -21,6 +21,12 @@ def test_plain_summary(monkeypatch):
         packet_count=1,
         bytes=100,
     )
+    monkeypatch.setattr(
+        "netwatchdog.utils.geoip.lookup",
+        lambda ip: {"1.1.1.1": "A", "2.2.2.2": "B"}.get(ip),
+    )
+
     summary = summarize(stats, sessions)
     assert "TCP: 2" in summary
     assert "1.1.1.1:1234 -> 2.2.2.2:80" in summary
+    assert "A -> B" in summary


### PR DESCRIPTION
## Summary
- include geoip lookups in CSV/JSON exports
- show city/country info for active sessions in summary
- test geoip output using a mocked lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a6ebd0c88333a505ee67c98988f9